### PR TITLE
[devdays] Aggregrate translations by context

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Marek J. Laska, Research Square, LLC.",
+  "author": "Marek J. Laska, Scott Dover, Research Square, LLC.",
   "license": "MIT",
   "dependencies": {
     "request": "~2.67.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-poeditor-rs",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Translation library for po editor",
   "main": "download.js",
   "scripts": {

--- a/tasks/poeditor.js
+++ b/tasks/poeditor.js
@@ -36,6 +36,7 @@ function download(data, opts, done) {
     data.langs = [];
     for (var plang in data.languages.toLocal)
         data.langs.push(plang);
+
     recursiveGetExports(data, {}, function(exports) {
         for (var polang in exports) {
             grunt.log.writeln('->'.green, polang+':', exports[polang]);
@@ -106,14 +107,20 @@ function downloadExport(url, path, handler) {
         var convertedTranslations = {};
         for (var key in translations) {
             var trans = translations[key];
+            var context = trans.context.length === 0 ? 'common' : trans.context;
 
             if (trans.term.length === 0) {
                 continue;
             }
 
-            convertedTranslations[trans.term] = trans.definition && trans.definition.length > 0 ?
+            if (typeof convertedTranslations[context] === 'undefined') {
+                convertedTranslations[context] = {};
+            }
+
+            convertedTranslations[context][trans.term] = trans.definition && trans.definition.length > 0 ?
                 trans.definition : trans.term;
         }
+
         var contents = JSON.stringify(convertedTranslations);
         // Dump the json contents to a file
         fs.writeFile(path, contents, function(err) {


### PR DESCRIPTION
This updates the way translations are stored. Specifically, instead of
an object of `{"term": "value"}`, we now have...
```
{
  "common": {
    "term": "value"
  },
  "specific-context": {
     "term": "value"
  }
```