### PR TITLE
Only include constants when running download from cli

### DIFF
--- a/download.js
+++ b/download.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var request = require('request');
-var constants = require('./constants.js');
 
 var PoDownloader = function (
     lang,
@@ -21,6 +20,8 @@ PoDownloader.prototype.exportTranslationData = function(content) {
     content = JSON.stringify(content, null, 4)
     process.stdout.write(content);
     return;
+
+    var constants = require('./constants.js');
     fs.writeFile(__dirname + constants.OUTPUT_FILE, content, function(err) {
         if (err) {
             throw err;
@@ -86,6 +87,7 @@ if (require.main === module) {
         console.log('Usage: node ' + path.basename(process.argv[1]) + ' <lang>');
         process.abort();
     }
+    var constants = require('./constants.js');
     var project_id = process.argv[3] ? process.argv[3] : constants.PROJECT_ID;
     var downloader = new PoDownloader(process.argv[2], constants.ENDPOINT, constants.API_KEY, project_id, null)
     downloader.downloadTranslations();

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "grunt-poeditor-rs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Translation library for po editor",
   "main": "download.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Marek J. Laska, Scott Dover, Research Square, LLC.",
+  "author": "Marek J. Laska, Scott Dover, Robert Newton, Research Square, LLC.",
   "license": "MIT",
   "dependencies": {
     "request": "~2.67.0",


### PR DESCRIPTION
The way the constants file is referenced doesn't universally work. Since the intended purpose is to allow the constants to be in-place for cli use, it makes sense to only try pulling them in that context. 